### PR TITLE
Creazione CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Node.js CI
+
+on:
+  push:
+    branches:
+    - main
+
+  pull_request:
+    branches:
+    - main
+      
+jobs:
+  test:
+    runs-on: ubuntu-latest
+  
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+  
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+  
+      - name: Install dependencies
+        run: npm install
+  
+      - name: Run tests
+        run: npm test
+        
+      - name: Upload coverage as artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-report
+          path: coverage

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Per avviare l'applicazione ci sono diversi modi in base alla funzionalità che s
 
 per eseguire i test serve scrivere a terminale npm test
 
+---
+## Intergazione Continua
+La pipeline CI è configurata tramite GitHub Actions:
+
+trigger: automatici ad ogni commit
+file di configurazione: ./github/workflow/ci.yml
+risultati: i risultati dei test saranno visibili nelle Actions*
+
 l'obbiettivo finale è la coverage al 100%
-
-


### PR DESCRIPTION
Configurare un workflow di GitHub Actions per automatizzare l'esecuzione dei test ad ogni integrazione proposta, utilizzando un singolo job, e rendere accessibile il report di code coverage generato.

Il trigger parte non appena si fa merge su main o quando si fa una pull request sul main;
Il workflow esegue un solo job chiamato test-and-coverage che gira su Ubuntu;
Step:
- Scarica il codice dalla repositori
- Installa Node.js (ultima versione)
- Installa dipendenze
- Esegue i test con la coverage